### PR TITLE
Add goreleaseer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --force --tags
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ingore build files
 build/
+dist/
 cambak*
 !cambak.go

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,55 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+project_name: Cambak
+
+before:
+  hooks:
+    - go mod tidy
+    #- go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      # - windows # XXX: Not tested for Windows... yet.
+      - darwin
+      - freebsd
+      - openbsd
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+
+archives:
+  - replacements:
+      darwin: MacOS
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+
+nfpms:
+  - package_name: cambak
+    vendor: Themimitoof
+    homepage: https://github.com/themimitoof/cambak
+    maintainer: Michael V. <dev@mvieira.fr>
+    license: MIT
+    formats:
+      - apk
+      - deb
+      - rpm
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,15 +1,15 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
-project_name: Cambak
+project_name: cambak
 
 before:
   hooks:
     - go mod tidy
-    #- go generate ./...
 
 builds:
-  - env:
+  - id: cambak-binaries
+    env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X 'github.com/themimitoof/cambak/cmd.CambakVersion={{.Version}}' -X 'github.com/themimitoof/cambak/cmd.CambakCommit={{.Commit}}'
     goos:
       - linux
       # - windows # XXX: Not tested for Windows... yet.
@@ -17,21 +17,23 @@ builds:
       - freebsd
       - openbsd
     goarch:
-      - 386
       - amd64
       - arm
       - arm64
+    goarm:
+      - 7
 
 archives:
   - replacements:
       darwin: MacOS
       linux: Linux
       windows: Windows
-      386: i386
       amd64: x86_64
+      arm: armhf
 
 nfpms:
-  - package_name: cambak
+  - id: cambak-pkgs
+    package_name: cambak
     vendor: Themimitoof
     homepage: https://github.com/themimitoof/cambak
     maintainer: Michael V. <dev@mvieira.fr>
@@ -40,6 +42,14 @@ nfpms:
       - apk
       - deb
       - rpm
+    builds:
+      - cambak-binaries
+    replacements:
+      darwin: MacOS
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+      arm: armhf
 
 checksum:
   name_template: 'checksums.txt'
@@ -53,3 +63,8 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+release:
+  draft: true
+  footer: |
+    That's all for this new release of Cambak {{ .Tag }}!

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,13 +7,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CAMBAK_VERSION string = "0.1.1"
+var CambakVersion string
+var CambakCommit string
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Return the version of Cambak",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("%s version %s\n", color.GreenString("Cambak"), color.GreenString("%s", CAMBAK_VERSION))
+		fmt.Printf("%s version %s (commit: %s)\n", color.GreenString("Cambak"), color.GreenString("%s", CambakVersion), CambakCommit)
 	},
 }
 


### PR DESCRIPTION
This MR implements GoReleaser and the GitHub Actions to automate the creation of a release on GitHub.

When a tag is pushed, goReleaser is executed via GitHub actions, create a **draft** release with an archive for:
 - Linux
 - MacOS
 - FreeBSD
 - OpenBSD

targeting the architectures:
 - amd64
 - armhf (armv7)
 - arm64

It also creates DEB, RPM and APK packages. During the build, we also inject the tag version and the commit id in the `cmd.version` file.

Screenshot of a test release:

![image](https://user-images.githubusercontent.com/1113348/163545530-1ac263bc-a206-49ff-882e-05796682d839.png)
